### PR TITLE
Prepare repo for Claude plugin directory submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,11 @@ Search results often contain enough information to answer. Your agent can fetch 
 
 ## Free access and higher limits
 
-The free endpoint is rate-limited. For higher limits, connect a Parallel account using an API key or OAuth. Authenticated usage follows your account's pricing and limits. See the [authentication instructions](https://docs.parallel.ai/integrations/mcp/search-mcp#installation).
+The free tier includes both tools with no account or API key, subject to rate limits. For higher limits, connect a Parallel account: point your client at the authenticated endpoint `https://search.parallel.ai/mcp-oauth` (OAuth), or follow the [authentication instructions](https://docs.parallel.ai/integrations/mcp/search-mcp#installation) for API-key setups. Authenticated usage is billed under your account's pricing and limits — see [parallel.ai](https://parallel.ai) for pricing. The tools behave the same on both tiers; only limits and billing differ.
 
-Parallel hosts the service. Search queries and requested URLs are sent to Parallel under the [Customer Terms](https://parallel.ai/customer-terms) and [Privacy Policy](https://parallel.ai/privacy-policy).
+## Privacy and terms
+
+Parallel hosts the service. Search queries and requested URLs are sent to Parallel and handled under the [Customer Terms](https://parallel.ai/customer-terms) and [Privacy Policy](https://parallel.ai/privacy-policy). The server only receives what the tools send it — search queries and the URLs you ask it to fetch — and does not read your conversation, files, or other context.
 
 ## Troubleshooting
 
@@ -119,9 +121,15 @@ Parallel hosts the service. Search queries and requested URLs are sent to Parall
 - **Hit a rate limit:** wait before retrying, or connect your Parallel account for higher limits.
 - **Still stuck:** check the [setup guide](https://docs.parallel.ai/integrations/mcp/search-mcp#troubleshooting) or [open an issue](https://github.com/parallel-web/search-mcp/issues). Include your client, version, and error message. Leave out API keys and other credentials.
 
+## Support and security
+
+- **Questions and bugs:** [open an issue](https://github.com/parallel-web/search-mcp/issues) with your client, version, and error message (leave out API keys and other credentials), or see the [documentation](https://docs.parallel.ai/integrations/mcp/search-mcp).
+- **Product support:** contact Parallel at [support@parallel.ai](mailto:support@parallel.ai).
+- **Security concerns:** report privately to [support@parallel.ai](mailto:support@parallel.ai) — see [SECURITY.md](SECURITY.md). Please don't file security reports as public issues.
+
 ## About this repo
 
-This is the official GitHub home for Parallel's hosted Search MCP. It contains this guide and Claude, Codex, and Cursor plugin configurations. All three use the same `.mcp.json`. You can suggest documentation fixes and examples here. The search service runs on Parallel's infrastructure; cloning this repo gives you the documentation and configuration files.
+This is the official GitHub home for Parallel's hosted Search MCP. It contains this guide and Claude, Codex, and Cursor plugin configurations. All three use the same `.mcp.json`. The Claude plugin also includes a `setup` skill ([skills/setup/SKILL.md](skills/setup/SKILL.md)) that walks Claude through verifying the connection, troubleshooting, and upgrading to an authenticated Parallel account. You can suggest documentation fixes and examples here. The search service runs on Parallel's infrastructure; cloning this repo gives you the documentation and configuration files.
 
 For CLI-based search, research, and enrichment, see the separate [Parallel CLI skills plugin](https://github.com/parallel-web/parallel-agent-skills).
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Search results often contain enough information to answer. Your agent can fetch 
 
 ## Free access and higher limits
 
-The free tier includes both tools with no account or API key, subject to rate limits. For higher limits, connect a Parallel account: point your client at the authenticated endpoint `https://search.parallel.ai/mcp-oauth` (OAuth), or follow the [authentication instructions](https://docs.parallel.ai/integrations/mcp/search-mcp#installation) for API-key setups. Authenticated usage is billed under your account's pricing and limits — see [parallel.ai](https://parallel.ai) for pricing. The tools behave the same on both tiers; only limits and billing differ.
+The free tier includes both tools with no account or API key, subject to rate limits. For higher limits, connect a Parallel account: point your client at the authenticated endpoint `https://search.parallel.ai/mcp-oauth` (OAuth), or follow the [authentication instructions](https://docs.parallel.ai/integrations/mcp/search-mcp#installation) for API-key setups. Authenticated usage is billed under your account's pricing and limits. See [parallel.ai](https://parallel.ai) for pricing. Both tiers include the same two tools. Authenticated connections also let you [configure search behavior](https://docs.parallel.ai/integrations/mcp/search-mcp#configure-search-behavior), including search modes, result counts, and domain filters. Anonymous requests ignore these settings.
 
 ## Privacy and terms
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security policy
+
+## Reporting a vulnerability
+
+If you find a security issue in this repository's configuration files or in the hosted Parallel Search MCP service (`search.parallel.ai`), please report it privately to **support@parallel.ai**. Do not open a public GitHub issue for security reports.
+
+Include what you found, how to reproduce it, and the impact you believe it has. We'll acknowledge your report and follow up as we investigate.
+
+## Scope
+
+- This repository contains documentation and client configuration only; the search service runs on Parallel's infrastructure.
+- The MCP server's tools (`web_search`, `web_fetch`) are read-only and require no credentials on the free tier. The authenticated endpoint uses OAuth; never share API keys or tokens in issues or reports.
+
+## Service and data handling
+
+Use of the hosted service is governed by the [Customer Terms](https://parallel.ai/customer-terms) and [Privacy Policy](https://parallel.ai/privacy-policy).

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: setup
+description: Set up, verify, or troubleshoot the Parallel Search MCP connection bundled with this plugin. Use when the user installs or activates the Parallel Search plugin, asks to connect or configure Parallel search, reports that web_search or web_fetch tools are missing, hits a rate limit, or wants to upgrade from the free endpoint to an authenticated Parallel account for higher limits.
+---
+
+# Parallel Search MCP setup
+
+This plugin bundles one remote MCP server:
+
+- **Name:** `parallel-search`
+- **URL:** `https://search.parallel.ai/mcp`
+- **Transport:** Streamable HTTP
+- **Authentication:** none for the free tier
+
+The server is hosted by Parallel; nothing runs locally. It exposes two read-only tools: `web_search` (search the web, returns excerpts with source links) and `web_fetch` (read specific URLs).
+
+## 1. Verify the free connection
+
+The free endpoint needs no account, API key, or login.
+
+1. Check that the `parallel-search` MCP server is connected and that `web_search` and `web_fetch` appear in the available tools.
+2. If the client prompted for approval of the MCP connection, the user must approve it once. This approval is a client-side step and is not a Parallel login.
+3. Run a quick test: search for something verifiable (for example, the latest stable Node.js release) and confirm results come back with source links.
+
+If the tools are present and the test search returns results, setup is complete — tell the user they're ready to go and that no account is needed.
+
+## 2. Troubleshoot
+
+- **Tools missing:** start a new session so the client reloads MCP servers, then check the client's MCP connection list. Confirm the URL is exactly `https://search.parallel.ai/mcp`.
+- **Duplicate servers:** if the user previously added `parallel-search` manually (for example via `claude mcp add`), the plugin and the manual entry point at the same endpoint. Keep one and remove the other to avoid duplicate tools.
+- **Asked to log in to Parallel:** the free endpoint is `/mcp`. A login prompt means the client is pointed at `/mcp-oauth`, the authenticated endpoint. Switch back to `/mcp` unless the user wants the paid tier (see below).
+- **Errors from the server:** report the error message to the user verbatim and suggest retrying. For persistent problems, direct them to the [setup guide](https://docs.parallel.ai/integrations/mcp/search-mcp#troubleshooting) or [GitHub issues](https://github.com/parallel-web/search-mcp/issues).
+
+## 3. Upgrade to higher limits (paid)
+
+The free endpoint is rate-limited. If the user hits rate limits or asks for higher throughput:
+
+1. Explain the trade-off: connecting a Parallel account lifts the free-tier rate limits, and authenticated usage is billed under the account's pricing and limits.
+2. Point them to the authenticated endpoint `https://search.parallel.ai/mcp-oauth`, which uses OAuth. Replace the free server entry with the authenticated one (same server name, new URL) so tools aren't duplicated. The client will walk the user through the OAuth flow in their browser.
+3. For clients that don't support OAuth for MCP, follow the [authentication instructions](https://docs.parallel.ai/integrations/mcp/search-mcp#installation) in Parallel's docs.
+
+Never ask the user to paste an API key or other credentials into the chat. If a key is required by their client's configuration format, direct them to place it in the client's config file or an environment variable themselves.
+
+## Rules
+
+- Do not modify the user's MCP configuration without telling them what will change.
+- Do not remove or reconfigure unrelated MCP servers.
+- If anything here conflicts with what the connected server actually reports, trust the server and Parallel's documentation at https://docs.parallel.ai/integrations/mcp/search-mcp.


### PR DESCRIPTION
## What changed

Adds the pieces Anthropic's [Software Directory Policy](https://support.claude.com/en/articles/13145358-anthropic-software-directory-policy) expects before we submit this repo to the Claude plugin directory (Cowork + Claude Code):

- **`skills/setup/SKILL.md`** — a setup skill bundled with the Claude plugin, per the [plugin submission docs](https://claude.com/docs/plugins/submit). It guides Claude through verifying the free connection, troubleshooting (missing tools, duplicate servers, unexpected login prompts), and upgrading to the authenticated `/mcp-oauth` endpoint for higher limits. Includes guardrails: never ask users to paste credentials into chat, don't touch unrelated MCP config.
- **`SECURITY.md`** — private vulnerability reporting channel and scope notes (policy §3B).
- **README** — explicit free-vs-paid disclosure (what free includes, where billing starts — policy §2B), a dedicated "Privacy and terms" section with data-handling notes (§3A, §1D), a "Support and security" contact section (§3B), and a pointer to the new setup skill.

## Why

We're submitting this repo as the public source for the Parallel Search plugin (free tier + paid authenticated tier). The directory review checks for privacy policy links, support contacts, working example prompts, and accurate free/paid descriptions.

## Reviewer notes

- `claude plugin validate .` passes on this branch.
- Contact address used throughout is **support@parallel.ai** — please confirm that alias is live before we submit.
- The setup skill states that `/mcp-oauth` is the authenticated OAuth endpoint; please confirm that matches current server behavior, since the policy requires OAuth 2.0 for authenticated remote MCP servers and reviewers will test it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)