### PR TITLE
Declare maintainer for the Glama Search MCP listing

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "georgeatparallel"
+  ]
+}


### PR DESCRIPTION
Glama lists this repository as a Search MCP integration. To let someone claim and maintain an organization-owned repository listing, Glama reads the GitHub usernames declared in a root `glama.json`. This repo has no declaration, which leaves the ownership step incomplete.

The new file names `georgeatparallel` as a maintainer using Glama's published schema. Once the file is merged and Glama picks it up, that account can use the claim flow for the [existing repository listing](https://glama.ai/mcp/servers/parallel-web/search-mcp).

The JSON passed the published schema constraints and `git diff --check`. This file does not itself claim the listing or change its endpoint, description, or health status. Glama's separate hosted connector still has its own ownership and metadata requirements.
