### PR TITLE
Add Gemini CLI extension for free Search MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ codex mcp add parallel-search --url https://search.parallel.ai/mcp
 
 Start a new Codex session and run `/mcp` to check the connection. See the [Codex MCP guide](https://developers.openai.com/codex/mcp/) for configuration options.
 
+### Gemini CLI
+
+```bash
+gemini extensions install https://github.com/parallel-web/search-mcp
+```
+
+Restart Gemini CLI and run `/mcp` to check that `parallel-search` is connected. The extension uses Streamable HTTP and requires no Parallel account or API key. If you already configured `parallel-search` manually, that configuration takes precedence over the extension. See the [extension guide](https://geminicli.com/docs/extensions/) for installation and update options.
+
 ### OpenCode
 
 Merge this into your project's `opencode.json`:

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,10 @@
+{
+  "name": "parallel-search",
+  "version": "0.1.0",
+  "description": "Search the web and read pages from your coding agent. Free to start, no API key needed.",
+  "mcpServers": {
+    "parallel-search": {
+      "httpUrl": "https://search.parallel.ai/mcp"
+    }
+  }
+}


### PR DESCRIPTION
Gemini CLI reads a repository's `gemini-extension.json` to find the MCP servers an extension provides. This repo already documents the hosted Search MCP, but it has no Gemini manifest, so users cannot install it with `gemini extensions install`.

This adds a manifest that registers `parallel-search` at `https://search.parallel.ai/mcp`. It uses Gemini's `httpUrl` field for Streamable HTTP, with no credentials or local server to configure. The README adds the install command and explains that an existing manual configuration with the same server name takes precedence.

Validated with Gemini CLI 0.59.0: extension validation and installation passed in an isolated configuration, and `mcp list` reported the server connected. Anonymous search and fetch calls also passed. Gallery discovery still requires the manifest on the default branch, the `gemini-cli-extension` repository topic, and a successful crawler pass; this PR alone does not publish a gallery listing.
